### PR TITLE
Fix GTK fatal errors and align POS publish version with TeamCity installer

### DIFF
--- a/LogicPOS.UI/Application/ApplicationIconHelper.cs
+++ b/LogicPOS.UI/Application/ApplicationIconHelper.cs
@@ -1,0 +1,75 @@
+using Gtk;
+using logicpos;
+using LogicPOS.UI.Settings;
+using System;
+using System.IO;
+using System.Reflection;
+
+namespace LogicPOS.UI.Application
+{
+    internal static class ApplicationIconHelper
+    {
+        internal static void ApplyGtkDefaultIcon()
+        {
+            var pixbuf = TryLoadPixbuf();
+            if (pixbuf == null)
+                return;
+
+            Gtk.Window.DefaultIcon = pixbuf;
+        }
+
+        internal static Gdk.Pixbuf TryLoadPixbuf()
+        {
+            foreach (var path in GetCandidateIconPaths())
+            {
+                if (!File.Exists(path))
+                    continue;
+
+                try
+                {
+                    using (var image = System.Drawing.Image.FromFile(path))
+                    {
+                        return Utils.ImageToPixbuf(image);
+                    }
+                }
+                catch
+                {
+                    // Try next candidate.
+                }
+            }
+
+            try
+            {
+                var exePath = Assembly.GetExecutingAssembly().Location;
+                if (string.IsNullOrWhiteSpace(exePath))
+                    return null;
+
+                using (var icon = System.Drawing.Icon.ExtractAssociatedIcon(exePath))
+                {
+                    if (icon == null)
+                        return null;
+
+                    using (var bitmap = icon.ToBitmap())
+                    {
+                        return Utils.ImageToPixbuf(bitmap);
+                    }
+                }
+            }
+            catch
+            {
+                return null;
+            }
+        }
+
+        private static string[] GetCandidateIconPaths()
+        {
+            var baseDir = AppDomain.CurrentDomain.BaseDirectory.TrimEnd('\\', '/');
+            return new[]
+            {
+                Path.Combine(baseDir, AppSettings.AppIcon),
+                Path.Combine(baseDir, AppSettings.Paths.Images, AppSettings.AppIcon),
+                Path.Combine(baseDir, "Assets", "Images", AppSettings.AppIcon),
+            };
+        }
+    }
+}

--- a/LogicPOS.UI/Application/Errors/ErrorHandlingService.cs
+++ b/LogicPOS.UI/Application/Errors/ErrorHandlingService.cs
@@ -68,6 +68,16 @@ namespace LogicPOS.UI.Errors
                 errorMessage.AppendLine(error.Description);
             }
 
+            if (sourceWindow == null)
+            {
+                System.Windows.MessageBox.Show(
+                    errorMessage.ToString(),
+                    "Erro — logicPOS",
+                    System.Windows.MessageBoxButton.OK,
+                    System.Windows.MessageBoxImage.Error);
+                return;
+            }
+
             new CustomAlert(sourceWindow)
                            .WithMessage(errorMessage.ToString())
                            .WithMessageType(MessageType.Error)

--- a/LogicPOS.UI/Components/Alerts/Simple/SimpleAlert.cs
+++ b/LogicPOS.UI/Components/Alerts/Simple/SimpleAlert.cs
@@ -1,6 +1,9 @@
 using Gtk;
 using LogicPOS.Utility;
 using LogicPOS.Globalization;
+using WinFormsMessageBox = System.Windows.Forms.MessageBox;
+using WinFormsMessageBoxButtons = System.Windows.Forms.MessageBoxButtons;
+using WinFormsMessageBoxIcon = System.Windows.Forms.MessageBoxIcon;
 
 namespace LogicPOS.UI.Alerts
 {
@@ -15,16 +18,58 @@ namespace LogicPOS.UI.Alerts
 
         public ResponseType ShowAlert()
         {
-            MessageDialog dialog = new MessageDialog(_parentWindow,
-                                                     _flags,
-                                                     _messageType,
-                                                     _buttonsType,
-                                                     _message);
-            dialog.Title = _title;
-            ResponseType responseType = (ResponseType)dialog.Run();
-            dialog.Destroy();
+            if (!CanUseGtkDialog())
+            {
+                ShowWinFormsFallback();
+                return ResponseType.Ok;
+            }
 
-            return responseType;
+            using (var dialog = new MessageDialog(
+                _parentWindow,
+                _flags,
+                _messageType,
+                _buttonsType,
+                _message))
+            {
+                dialog.Title = _title;
+                return (ResponseType)dialog.Run();
+            }
+        }
+
+        private static bool CanUseGtkDialog()
+        {
+            try
+            {
+                return Gdk.Screen.Default != null;
+            }
+            catch
+            {
+                return false;
+            }
+        }
+
+        private void ShowWinFormsFallback()
+        {
+            WinFormsMessageBox.Show(
+                _message ?? string.Empty,
+                _title ?? "LogicPOS",
+                WinFormsMessageBoxButtons.OK,
+                MapMessageType(_messageType));
+        }
+
+        private static WinFormsMessageBoxIcon MapMessageType(MessageType type)
+        {
+            switch (type)
+            {
+                case MessageType.Error:
+                    return WinFormsMessageBoxIcon.Error;
+                case MessageType.Warning:
+                    return WinFormsMessageBoxIcon.Warning;
+                case MessageType.Question:
+                    return WinFormsMessageBoxIcon.Question;
+                default:
+                    return WinFormsMessageBoxIcon.Information;
+            }
         }
 
         public SimpleAlert WithParent(Window parentWindow)

--- a/LogicPOS.UI/Components/Windows/FrontOffice/POSBaseWindow.cs
+++ b/LogicPOS.UI/Components/Windows/FrontOffice/POSBaseWindow.cs
@@ -38,16 +38,11 @@ namespace LogicPOS.UI.Components.Windows
         private Color GetScreenBackgroundColorFromTheme(dynamic theme)
             => (theme.Globals.ScreenBackgroundColor as string).StringToColor();
 
-        private string GetAppIconFileLocation()
-        {
-            return string.Format("{0}{1}", AppSettings.Paths.Images, @"Icos\application.ico");
-        }
-
         private void SetAppIcon()
         {
-            string appIconFileLocation = GetAppIconFileLocation();
-
-            if (File.Exists(appIconFileLocation)) Icon = Utils.ImageToPixbuf(global::System.Drawing.Image.FromFile(appIconFileLocation));
+            var pixbuf = ApplicationIconHelper.TryLoadPixbuf();
+            if (pixbuf != null)
+                Icon = pixbuf;
         }
 
         private void ConfigureScreen(

--- a/LogicPOS.UI/LogicPOS.UI.csproj
+++ b/LogicPOS.UI/LogicPOS.UI.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\packages\MSBuild.Microsoft.VisualStudio.Web.targets.14.0.0.3\build\MSBuild.Microsoft.VisualStudio.Web.targets.props" Condition="Exists('..\packages\MSBuild.Microsoft.VisualStudio.Web.targets.14.0.0.3\build\MSBuild.Microsoft.VisualStudio.Web.targets.props')" />
 	<PropertyGroup>
@@ -102,27 +102,32 @@
     <Reference Include="System.Xml" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="WindowsBase" />
-	</ItemGroup>
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="**\*.cs" Exclude="obj\**\*.cs;Properties\**\*.cs;Resources\**\*.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Properties\Resources.Designer.cs">
+      <AutoGen>True</AutoGen>
+      <DesignTime>True</DesignTime>
+      <DependentUpon>Resources.resx</DependentUpon>
+    </Compile>
+    <Compile Include="Properties\Settings.Designer.cs">
+      <AutoGen>True</AutoGen>
+      <DesignTimeSharedInput>True</DesignTimeSharedInput>
+      <DependentUpon>Settings.settings</DependentUpon>
+    </Compile>
+    <Content Include="Assets\**\*.*">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
 	<ItemGroup>
-		<Compile Include="**\*.cs" Exclude="obj\**\*.cs;Properties\**\*.cs;Resources\**\*.cs"/>
-		<compile Include="Properties\AssemblyInfo.cs"/>
-		<Compile Include="Properties\Resources.Designer.cs">
-			<AutoGen>True</AutoGen>
-			<DesignTime>True</DesignTime>
-			<DependentUpon>Resources.resx</DependentUpon>
-		</Compile>
-		<Compile Include="Properties\Settings.Designer.cs">
-			<AutoGen>True</AutoGen>
-			<DesignTimeSharedInput>True</DesignTimeSharedInput>
-			<DependentUpon>Settings.settings</DependentUpon>
-		</Compile>
-		<Content Include="Assets\**\*.*">
-			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-		</Content>
-	</ItemGroup>
-  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
-	<ItemGroup>
-    <Content Include="application.ico" />
+    <Content Include="application.ico">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+    <Content Include="application.ico">
+      <Link>Assets\Images\application.ico</Link>
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
 		<Content Include="Assets\**\*.png;Assets\**\*.jpg">
 			<CopyToOutputDirectory>Always</CopyToOutputDirectory>
 		</Content>
@@ -256,6 +261,7 @@
 			<Version>9.0.2</Version>
 		</PackageReference>
 	</ItemGroup>
+  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
 	<Target Name="CopyGtkRuntime" AfterTargets="Build">
 		<ItemGroup>
       <GtkFiles Include="..\libs\GtkRuntime\**\*" />

--- a/LogicPOS.UI/Program.cs
+++ b/LogicPOS.UI/Program.cs
@@ -13,6 +13,7 @@ using System.Diagnostics;
 using System.Globalization;
 using System.IO;
 using System.Reflection;
+using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
 using WinFormsApplication = System.Windows.Forms.Application;
@@ -36,6 +37,7 @@ namespace LogicPOS.UI
         {
             Log.Information("Initializing GTK...");
             Gtk.Application.Init();
+            ApplicationIconHelper.ApplyGtkDefaultIcon();
             GtkThemeStyle.ParseTheme();
             // Exceptions in GTK# callbacks (signals, native→managed) do not reach AppDomain.UnhandledException.
             GLib.ExceptionManager.UnhandledException += OnGlibUnhandledException;
@@ -113,7 +115,11 @@ namespace LogicPOS.UI
 
                 if (ProgramIsAlreadyRunning())
                 {
-                    Quit();
+                    WinFormsMessageBox.Show(
+                        "Já existe uma instância do logicPOS em execução neste PC.",
+                        "logicPOS",
+                        WinFormsMessageBoxButtons.OK,
+                        WinFormsMessageBoxIcon.Information);
                     return;
                 }
 
@@ -146,10 +152,7 @@ namespace LogicPOS.UI
             catch (Exception ex)
             {
                 TryLogSerilogFatalAndFlush(ex, "An unhandled exception occurred in Main.");
-                SimpleAlerts.Error()
-                            .WithTitle("Erro inesperado")
-                            .WithMessage($"Ocorreu um erro inesperado: \nPor favor, contacte o suporte técnico.")
-                            .ShowAlert();
+                ShowFatalErrorMessageBox(ex);
             }
             finally
             {
@@ -168,25 +171,46 @@ namespace LogicPOS.UI
             return false;
         }
 
+        [DllImport("kernel32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
+        private static extern bool SetDllDirectory(string lpPathName);
+
         private static void ConfigureGtkRuntime()
         {
             string baseDir = AppDomain.CurrentDomain.BaseDirectory;
             string gtkPath = Path.Combine(baseDir, "GtkRuntime");
-            Environment.SetEnvironmentVariable("GTK_BASEPATH", gtkPath);
             string gtkBinPath = Path.Combine(gtkPath, "bin");
+            Environment.SetEnvironmentVariable("GTK_BASEPATH", gtkPath);
+
+            if (!Directory.Exists(gtkBinPath))
+            {
+                Debug.WriteLine($"GtkRuntime bin folder not found: {gtkBinPath}");
+                return;
+            }
+
+            SetDllDirectory(gtkBinPath);
             string currentPath = Environment.GetEnvironmentVariable("PATH") ?? string.Empty;
-            Environment.SetEnvironmentVariable("PATH", $"{currentPath};{gtkBinPath}");
+            if (currentPath.IndexOf(gtkBinPath, StringComparison.OrdinalIgnoreCase) < 0)
+            {
+                Environment.SetEnvironmentVariable("PATH", gtkBinPath + Path.PathSeparator + currentPath);
+            }
         }
 
         private static void ShowVersionAlerts()
         {
-            if (SystemVersionService.ApiVersion != SystemVersionService.PosVersion)
+            if (SystemVersionService.ApiVersion == SystemVersionService.PosVersion)
             {
-                SimpleAlerts.Warning()
-                       .WithTitle("Atenção")
-                       .WithMessage($"A versão da API ({SystemVersionService.ApiVersion}) difere da versão do aplicativo ({SystemVersionService.PosVersion}).\n Algumas partes do sistema podem não funcionar como esperado, convém usar versões iguais.")
-                       .ShowAlert();
+                return;
             }
+
+            string message =
+                $"A versão da API ({SystemVersionService.ApiVersion}) difere da versão do aplicativo ({SystemVersionService.PosVersion}).\n" +
+                "Algumas partes do sistema podem não funcionar como esperado; convém usar versões iguais.";
+
+            WinFormsMessageBox.Show(
+                message,
+                "Atenção — logicPOS",
+                WinFormsMessageBoxButtons.OK,
+                WinFormsMessageBoxIcon.Warning);
         }
 
         public static void Quit()

--- a/publish.ps1
+++ b/publish.ps1
@@ -1,6 +1,7 @@
 param (
     [string]$SolutionOrProject = "LogicPOS.UI\LogicPOS.UI.csproj",
     [string]$Configuration = "Release",
+    [string]$ProductVersion = "",
     [string]$OutputDir = "..\..\artifacts\publish\pos\"
 )
 
@@ -31,12 +32,28 @@ if (Test-Path $OutputDir) {
 
 # --- Build ---
 Log "Building $SolutionOrProject ($Configuration) using global MSBuild"
+if ($ProductVersion) {
+    Log "Product version: $ProductVersion"
+}
+
+$versionProperties = @()
+if (-not [string]::IsNullOrWhiteSpace($ProductVersion)) {
+    $v = $ProductVersion.Trim()
+    $parts = $v.Split('.')
+    $fileVersion = if ($parts.Count -eq 3) { "$v.0" } elseif ($parts.Count -ge 4) { $v } else { "$v.0.0" }
+    $versionProperties = @(
+        "/p:ApplicationVersion=$fileVersion",
+        "/p:AssemblyVersion=$fileVersion",
+        "/p:FileVersion=$fileVersion"
+    )
+}
 
 MSBuild $SolutionOrProject `
     /restore `
     /t:Clean,Build `
     /p:Configuration=$Configuration `
     /p:OutputPath=$OutputDir `
+    @versionProperties `
     /verbosity:minimal
 
 if ($LASTEXITCODE -ne 0) {

--- a/publish.ps1
+++ b/publish.ps1
@@ -1,6 +1,6 @@
 param (
     [string]$SolutionOrProject = "LogicPOS.UI\LogicPOS.UI.csproj",
-    [string]$Configuration = "Debug",
+    [string]$Configuration = "Release",
     [string]$OutputDir = "..\..\artifacts\publish\pos\"
 )
 
@@ -33,6 +33,7 @@ if (Test-Path $OutputDir) {
 Log "Building $SolutionOrProject ($Configuration) using global MSBuild"
 
 MSBuild $SolutionOrProject `
+    /restore `
     /t:Clean,Build `
     /p:Configuration=$Configuration `
     /p:OutputPath=$OutputDir `


### PR DESCRIPTION
## Summary
- Fix GTK app icon, fatal error dialogs (WinForms fallback when GTK unavailable), and publish defaults
- Accept ProductVersion in publish.ps1 and pass MSBuild version properties for TeamCity/WiX installer alignment (1.5.XX)

## Test plan
- [ ] Run publish.ps1 -Configuration Release -ProductVersion 1.5.216 and verify logicpos.exe file version
- [ ] Build installer via TeamCity build-installer.ps1
- [ ] Install over existing SQLite legacy installation


Made with [Cursor](https://cursor.com)